### PR TITLE
docs: install with mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ brew tap jedi4ever/tap
 brew install addt
 ```
 
+### Homebrew
+
+```bash
+mise use -g github:jedi4ever/addt
+```
+
 ### Verify Installation
 
 ```bash


### PR DESCRIPTION
Just add a quick mention of how to install `addt` using `mise` as it's getting more popular. And you get support in it for free by using Github releases.