### PR TITLE
fix: avoid conflict with local user ID on Linux

### DIFF
--- a/src/assets/docker/Dockerfile.base
+++ b/src/assets/docker/Dockerfile.base
@@ -47,9 +47,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Create user with matching UID/GID from host
-# Note: GID 20 may already exist (staff/dialout group), so we just add user to that group
-RUN (groupadd -g ${GROUP_ID} ${USERNAME} 2>/dev/null || true) \
-    && useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USERNAME} 2>/dev/null || usermod -u ${USER_ID} ${USERNAME} \
+# Note: node:*-slim images have a 'node' user with UID/GID 1000, remove it first to avoid conflicts
+RUN userdel -r node 2>/dev/null || true \
+    && groupdel node 2>/dev/null || true \
+    && (groupadd -g ${GROUP_ID} ${USERNAME} 2>/dev/null || true) \
+    && useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USERNAME} \
     && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Install UV (Python package manager) as the user using official install script


### PR DESCRIPTION
The Node Docker image has a node user with UID 1000 which conflicts with the UID most users will have on Linux. Since the node user doesn't seem to be used anywhere, I just removed it.
My guess is that you're on MacOS so didn't have the issue :smile: 