### PR TITLE
Add registry in image names so podman can use them out of the box

### DIFF
--- a/src/assets/docker/Dockerfile.base
+++ b/src/assets/docker/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=22
-FROM node:${NODE_VERSION}-slim
+FROM docker.io/node:${NODE_VERSION}-slim
 
 # Build arguments for user ID and group ID
 ARG USER_ID=1000

--- a/src/assets/orbstack/Dockerfile.base
+++ b/src/assets/orbstack/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=22
-FROM node:${NODE_VERSION}-slim
+FROM docker.io/node:${NODE_VERSION}-slim
 
 # Build arguments for user ID and group ID
 ARG USER_ID=1000

--- a/src/assets/podman/Dockerfile.base
+++ b/src/assets/podman/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=22
-FROM node:${NODE_VERSION}-slim
+FROM docker.io/node:${NODE_VERSION}-slim
 
 # Build arguments for user ID and group ID
 ARG USER_ID=1000


### PR DESCRIPTION
Let's not keep implicit registry references so it works with any container runtime right away.